### PR TITLE
Allow index and in operators on result objects Fixes #1

### DIFF
--- a/braintreehttp/http_response.py
+++ b/braintreehttp/http_response.py
@@ -8,7 +8,7 @@ def setattr_mixed(dest, key, value):
 def construct_object(name, data, cls=object):
     if isinstance(data, dict):
         iterator = iter(data)
-        dest = type(str(name), (cls,), {})
+        dest = Result(data)
     elif isinstance(data, list):
         iterator = range(len(data))
         dest = []
@@ -31,6 +31,21 @@ def construct_object(name, data, cls=object):
             setattr_mixed(dest, k, v)
 
     return dest
+
+
+class Result(object):
+
+    def __init__(self, data):
+        self._dict = data;
+
+    def dict(self):
+        return self._dict
+
+    def __contains__(self, key):
+        return key in self._dict
+
+    def __getitem__(self, key):
+        return self._dict[key]
 
 
 class HttpResponse(object):

--- a/tests/http_response_test.py
+++ b/tests/http_response_test.py
@@ -95,6 +95,89 @@ class HttpResponseTest(unittest.TestCase):
         resp = HttpResponse({}, 200)
         self.assertIsNone(resp.result)
 
+    def testHttpResponse_dict_returnsDataAsDictionary(self):
+        obj = {
+            "int": 100,
+            "str": "value",
+            "list": [
+                [
+                    {
+                        "key": "value",
+                        "key_two": ["value_two"]
+                    }
+                ],
+                [
+                    {
+                        "key_three": "value_three",
+                        "key_four": "value_four"
+                    }
+                ]
+            ],
+        }
+
+        resp = HttpResponse(obj, 200)
+        self.assertDictEqual(obj, resp.result.dict())
+
+    def testHttpResponse_resultSuportsInOperator(self):
+        obj = {
+            "int": 100,
+            "str": "value",
+            "list": [
+                [
+                    {
+                        "key": "value",
+                        "key_two": ["value_two"]
+                    }
+                ],
+                [
+                    {
+                        "key_three": "value_three",
+                        "key_four": "value_four"
+                    }
+                ]
+            ],
+        }
+
+        resp = HttpResponse(obj, 200)
+
+        self.assertTrue('int' in resp.result)
+    
+    def testHttpResponse_listResultSuportsInOperator(self):
+        obj = ['one', 'two', 'three']
+
+        resp = HttpResponse(obj, 200)
+
+        self.assertTrue('one' in resp.result)
+
+    def testHttpResponse_supportsIndexOperator(self):
+        obj = {
+            "int": 100,
+            "str": "value",
+            "list": [
+                [
+                    {
+                        "key": "value",
+                        "key_two": ["value_two"]
+                    }
+                ],
+                [
+                    {
+                        "key_three": "value_three",
+                        "key_four": "value_four"
+                    }
+                ]
+            ],
+        }
+
+        resp = HttpResponse(obj, 200)
+
+        self.assertEquals(100, resp.result['int'])
+        self.assertEquals('value', resp.result['str'])
+        self.assertEquals('value', resp.result['list'][0][0]['key'])
+        self.assertEquals('value_two', resp.result['list'][0][0]['key_two'][0])
+        self.assertEquals('value_three', resp.result['list'][1][0]['key_three'])
+        self.assertEquals('value_four', resp.result['list'][1][0]['key_four'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Addresses issue #1 regarding supporting index operators on result objects, and PR #3, regarding the ability to access the raw backing dictionary behind the result object.

**cc:**
@depau
@shulcsm 